### PR TITLE
Autocomplete search for place facets except AdministrativeRegions

### DIFF
--- a/dr-app/public/css/spatial_search.css
+++ b/dr-app/public/css/spatial_search.css
@@ -722,3 +722,15 @@ table.table-filters tbody tr:nth-child(even) {
     padding: 1px;
     border: none;
 }
+
+/* autocomplete styles */
+
+.ui-autocomplete {
+    max-height: 100px;
+    overflow-y: auto;
+    /* prevent horizontal scrollbar */
+    overflow-x: hidden;
+}
+* html .ui-autocomplete {
+    height: 100px;
+}

--- a/dr-app/public/js/query.js
+++ b/dr-app/public/js/query.js
@@ -101,6 +101,64 @@ async function getAdministrativeRegion() {
     return {'regions':formattedResults};
 }
 
+async function getZipCodeArea() {
+    let formattedResults = [];
+
+    let zipcodeQuery = `
+    select distinct ?zipcode ?zipcodeArea where {
+        ?zipcodeArea rdf:type kwg-ont:ZipCodeArea;
+                     kwg-ont:hasZipCode ?zipcode.
+    } ORDER BY ASC(?zipcode)`;
+
+    let queryResults = await query(zipcodeQuery);
+    for (let row of queryResults) {
+        let zipcode = row.zipcode.value;
+        let zipcodeArea = row.zipcodeArea.value;
+        formattedResults[zipcode] = zipcodeArea;
+    }
+
+    return {'zipcodes':formattedResults};
+}
+
+async function getUSClimateDivision() {
+    let formattedResults = [];
+
+    let divisionQuery = `
+    select distinct ?division ?divison_label where {
+        ?division rdf:type kwg-ont:USClimateDivision;
+                  rdfs:label ?divison_label.
+    } ORDER BY ASC(?divison_label)`;
+
+    let queryResults = await query(divisionQuery);
+    for (let row of queryResults) {
+        let division = row.division.value;
+        let divison_label = row.divison_label.value;
+        formattedResults[divison_label] = division;
+    }
+
+    return {'divisions':formattedResults};
+}
+
+
+async function getNWZone() {
+    let formattedResults = [];
+
+    let nwzoneQuery = `
+    select distinct ?nwzone ?nwzone_label where {
+        ?nwzone rdf:type kwg-ont:NWZone;
+                rdfs:label ?nwzone_label.
+    } ORDER BY ASC(?nwzone_label)`;
+
+    let queryResults = await query(nwzoneQuery);
+    for (let row of queryResults) {
+        let nwzone = row.nwzone.value;
+        let nwzone_label = row.nwzone_label.value;
+        formattedResults[nwzone_label] = nwzone;
+    }
+
+    return {'nwzones':formattedResults};
+}
+
 //New search function for place in stko-kwg
 async function getPlaceSearchResults(pageNum, recordNum, parameters) {
     let formattedResults = [];

--- a/dr-app/public/js/results_search.js
+++ b/dr-app/public/js/results_search.js
@@ -507,6 +507,54 @@ kwgApp.controller("results-controller", function($scope) {});
 
 kwgApp.controller("spatialmap-controller", function($scope) {});
 
+kwgApp.directive('autocomplete', function() {
+    return {
+        restrict: 'A',
+        require : 'ngModel',
+        link : function (scope, element, attrs, ngModelCtrl) {
+            getZipCodeArea().then(function(data) {
+                if (element[0] == angular.element('#placeFacetsZip')[0])
+                {
+                  element.autocomplete({
+                      source: Object.keys(data['zipcodes']),
+                      select:function (event,ui) {
+                        console.log(ui);
+                          ngModelCtrl.$setViewValue(ui.item);
+                          scope.$apply();
+                      }
+                    });
+                }
+            });
+            getUSClimateDivision().then(function(data) {
+                if (element[0] == angular.element('#placeFacetsUSCD')[0])
+                {
+                  element.autocomplete({
+                      source: Object.keys(data['divisions']),
+                      select:function (event,ui) {
+                        console.log(ui);
+                          ngModelCtrl.$setViewValue(ui.item);
+                          scope.$apply();
+                      }
+                    });
+                }
+            });
+            getNWZone().then(function(data) {
+                if (element[0] == angular.element('#placeFacetsNWZ')[0])
+                {
+                  element.autocomplete({
+                      source: Object.keys(data['nwzones']),
+                      select:function (event,ui) {
+                        console.log(ui);
+                          ngModelCtrl.$setViewValue(ui.item);
+                          scope.$apply();
+                      }
+                    });
+                }
+            });           
+        }
+    }
+});
+
 var init = function() {
     setTimeout(() => {
         // -77.036667, lng: 38.895

--- a/dr-app/public/pages/dr_resultsSearch.html
+++ b/dr-app/public/pages/dr_resultsSearch.html
@@ -39,13 +39,13 @@
                 <p class="filter-title">PLACE</p>
                 <div class="filter">
                     <div>Administrative Region</div>
-                    <input type="text" class="form-control" id="placeFacetsRegion" ng-model="placeFacetsRegion" ng-blur="placeFacetChanged()" placeholder="Find an Administrative Region...">
+                    <input autocomplete="true" type="text" class="form-control" id="placeFacetsRegion" ng-model="placeFacetsRegion" ng-blur="placeFacetChanged()" placeholder="Find an Administrative Region...">
                     <div>Zip Code</div>
-                    <input type="text" class="form-control" id="placeFacetsZip" ng-model="placeFacetsZip" ng-blur="placeFacetChanged()" placeholder="Find a Zip Code...">
+                    <input autocomplete="true" type="text" class="form-control" id="placeFacetsZip" ng-model="placeFacetsZip" ng-blur="placeFacetChanged()" placeholder="Find a Zip Code...">
                     <div>US Climate Division</div>
-                    <input type="text" class="form-control" id="placeFacetsUSCD" ng-model="placeFacetsUSCD" ng-blur="placeFacetChanged()" placeholder="Find a US Climate Division...">
+                    <input autocomplete="true" type="text" class="form-control" id="placeFacetsUSCD" ng-model="placeFacetsUSCD" ng-blur="placeFacetChanged()" placeholder="Find a US Climate Division...">
                     <div>National Weather Zone</div>
-                    <input type="text" class="form-control" id="placeFacetsNWZ" ng-model="placeFacetsNWZ" ng-blur="placeFacetChanged()" placeholder="Find a National Weather Zone...">
+                    <input autocomplete="true" type="text" class="form-control" id="placeFacetsNWZ" ng-model="placeFacetsNWZ" ng-blur="placeFacetChanged()" placeholder="Find a National Weather Zone...">
                 </div>
             </li>
 

--- a/dr-app/public/views/homepage.html
+++ b/dr-app/public/views/homepage.html
@@ -20,7 +20,9 @@
     <link rel="stylesheet" href="css/spatial_search.css">
 
     <!-- JQuery -->
-    <script src="https://cdn.staticfile.org/jquery/1.10.2/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.2/jquery-ui.min.js"></script>
+    <link rel="stylesheet" href="http://code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css" />
 
     <!-- Angular.js-->
     <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.2.25/angular.min.js"></script>


### PR DESCRIPTION
1. Autocomplete search is done for all the other place facets except AdministrativeRegions based on this tutorial (https://embed.plnkr.co/LI4Qp8/).

2. Autocomplete search can match any substrings typed by a user with any in the query result.

3. Documentation here (https://material.angularjs.org/latest/demo/autocomplete) did not really work for me. 