### PR TITLE
Add spatial search

### DIFF
--- a/dr-app/public/views/homepage.html
+++ b/dr-app/public/views/homepage.html
@@ -53,6 +53,8 @@
     <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.3.0/dist/MarkerCluster.css" />
     <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.3.0/dist/MarkerCluster.Default.css" />
 
+    <!-- Turf -->
+    <script src='https://unpkg.com/@turf/turf@6/turf.min.js'></script>
 
     <link href="https://unpkg.com/bootstrap-table@1.18.3/dist/bootstrap-table.min.css" rel="stylesheet">
     <script src="https://unpkg.com/bootstrap-table@1.18.3/dist/bootstrap-table.min.js"></script>


### PR DESCRIPTION
1. Spatial search functions are added for place, hazard, and expert search. Particularly, expert spatial search is done by comparing affiliation geometry and the drawn circle. However, I think there is something wrong with the spatial index in our graph so no results will be returned.
2. We don't have `geof` in our graph, so I used Turf (https://turfjs.org/docs/#circle) that @myles28 suggested to generate a polygon that serve as an approximation for the circle and then I converted the geometry of this polygon into its WKT format.
3. The URL will also update as the user finished drawing the circle. However, the URL will remain to have coordinates, radius, etc., but no circle will show on the map when a user refresh the webpage. This needs to be fixed and there is more to be done in the frontend.