### PR TITLE
Update endpoint addresses

### DIFF
--- a/dr-app/public/config.json
+++ b/dr-app/public/config.json
@@ -2,7 +2,7 @@
     "description":"configuration for full-text search on KnowWhereGraph",
     "repository": [
         {
-            "endpoint":"http://stko-roy.geog.ucsb.edu:7202/repositories/KnowWhereGraph-V1"
+            "endpoint":"http://stko-roy.geog.ucsb.edu/graphdb/repositories/KnowWhereGraph-V1"
         },
         {
             "endpoint":"http://stko-kwg.geog.ucsb.edu/sparql",

--- a/es-connector-setup-info.md
+++ b/es-connector-setup-info.md
@@ -6,7 +6,7 @@ Type the following SPARQL queries for the index creation.
 
 ### Main graph
 
-The repository used is KWG-V2 on http://stko-kwg.geog.ucsb.edu:7200.
+The repository used is KWG-V2 on http://stko-kwg.geog.ucsb.edu/graphdb.
 
 #### SPARQL Query
 


### PR DESCRIPTION
Super small change to account for the upcoming changes to the graphdb endpoints. The stko-kwg endpoint doesn't need to change because it's set the the `/sparql` endpoint-which hides the GraphDB port from users.