### PR TITLE
Table state fix

### DIFF
--- a/dr-app/public/js/results_search.js
+++ b/dr-app/public/js/results_search.js
@@ -381,7 +381,7 @@ kwgApp.controller("spatialSearchController", function($scope, $timeout, $locatio
                     currentQuery=queryIdentifier;
                     prepareNewTable(activeTabName);
                     response.then(function(result) {
-                      var selectors = displayTableByTabName(activeTabName, response, "resultsSearchMap");
+                      var selectors = displayTableByTabName(activeTabName, result, "resultsSearchMap");
                         var countResults = result["count"];
                         displayPagination(activeTabName, selectors, countResults, parameters, "spatialSearchDraw");
                     });
@@ -513,7 +513,7 @@ kwgApp.controller("spatialSearchController", function($scope, $timeout, $locatio
           if (currentQuery != queryIdentifier) {
             return;
           }
-          var selectors = displayTableByTabName(activeTabName, response, "hazardFacetChanged");
+          var selectors = displayTableByTabName(activeTabName, result, "hazardFacetChanged");
             var countResults = result["count"];
             displayPagination(activeTabName, selectors, countResults, parameters, "hazardFacetChanged");
         });
@@ -559,7 +559,7 @@ kwgApp.controller("spatialSearchController", function($scope, $timeout, $locatio
           if (currentQuery != queryIdentifier) {
             return;
           }
-          var selectors = displayTableByTabName(activeTabName, response, "selectHazard");
+          var selectors = displayTableByTabName(activeTabName, result, "selectHazard");
             var countResults = result["count"];
             displayPagination(activeTabName, selectors, countResults, parameters, from="selectHazard");
         });
@@ -586,14 +586,13 @@ kwgApp.controller("spatialSearchController", function($scope, $timeout, $locatio
           if (currentQuery != queryIdentifier) {
             return;
           }
-          var selectors = displayTableByTabName(activeTabName, response, "resultsSearchMap");
+          var selectors = displayTableByTabName(activeTabName, result, "resultsSearchMap");
             var countResults = result["count"];
             displayPagination(activeTabName, selectors, countResults, parameters, "selectTopic");
         });
     }, debounceTimeout);
 
     $scope.selectRegion = debounce(function() {
-      let queryIdentifier = 6;
         var parameters = getParameters();
 
         if (parameters["facetRegions"].length > 0) {
@@ -614,7 +613,7 @@ kwgApp.controller("spatialSearchController", function($scope, $timeout, $locatio
           if (currentQuery != queryIdentifier) {
             return;
           }
-          var selectors = displayTableByTabName(activeTabName, response, "selectRegion");
+          var selectors = displayTableByTabName(activeTabName, result, "selectRegion");
             var countResults = result["count"];
             displayPagination(activeTabName, selectors, countResults, parameters, "selectRegion");
         });
@@ -1005,14 +1004,12 @@ var displayTableByTabName = function(activeTabName, result, from="") {
     var countResults = null;
     var recordResults = null;
     var tableBody = angular.element(selectors["tbody"] + " tbody");
-
       // When we get the result, clear the child elements of the table so that they're not
       // appended to existing rows
       angular.element(selectors['tbodyRes']).children().remove();
       angular.element('#loading').remove();
       countResults = result["count"];
       recordResults = result["record"];
-
       var attributeLinks = [];
       var tableBodyAttributes = [];
 


### PR DESCRIPTION
This solves a few bugs in the data table that haven't been reported yet and fixes _most_ of issue #153.

The overall problem is that if two queries (that eventually end up mutating the data table) are made, the'll _both_ overwrite the data table. The scenario is this:

A user lands on the main faceted search page and ends up on the 'Hazard' page. They click the 'Place' tab before the hazard query is finished. The places query will finish first because the query is faster. Its data is written to the table. Then, some number of seconds later the Hazards query finishes and overwrites the data that the Places query had written. This can be thought of as a race condition with writing to the data table.

Another example is if you land on the Hazards page and, before the main query finishes you select a facet. The facet query will return first, but when the initial query to get _all_ the information finishes it will overwrite the data table.

To get around this, we need to know which query can write to the data table and when. This means that each query that ends in changing the state of the data table needs to have some sort of identifier. I ended up assigning a uuid to each one. A new global variable `currentQuery` was created to hold the identifier of the most recent query. When each query finishes, it asks itself "Am I the most recent query that writes to the data table?" (see line 427, etc). If not, exit and don't write to the table. If it _is_, then go ahead and write to the table.

In doing this I split out some of the code that was running when promises resolved (prepareNewTable) so that the UI updates quickly for the user. 


_There's one remaining issue here and it has to do with variable scoping_. If the same query function is called twice, for example `clickTab` gets called twice from someone clicking tabs... `queryIdentifier` in the function shares a single state between _both_ calls, so `if (currentQuery != queryIdentifier)` will always return true. To get around this we want to get the query identifier out of the _promise_. To do this I suspect we'll want to pass its id into the call to `sendQueries`, and then construct a new promise that has both the query results _and_ the identifier. Since this is sort of an edge case (it will mainly manifest itself clicking between tabs) I'm leaving it off for now, but happy to tackle it when other showstopping bugs are fixed.


### Testing

Because this change effects the way the table works _for every query_, lots of testing is recommended. I've tested this under a number of different scenarios, but I don't know all of the common user workflows. I'd appreciate it if folks could check this branch out and click around with different facets and check that they're seeing expected results. 

