### PR TITLE
Distinguish between places connected to S2 cells and places associated with hazards through kwg-ont:locatedIn relations in hazard selection queries

### DIFF
--- a/dr-app/public/cache/us_admin_regions_nonhierarchical.json
+++ b/dr-app/public/cache/us_admin_regions_nonhierarchical.json
@@ -1,0 +1,32002 @@
+{
+  "head" : {
+    "vars" : [
+      "admin",
+      "admin_label"
+    ]
+  },
+  "results" : {
+    "bindings" : [
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cherokee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chilton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Choctaw"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clarke"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clay"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cleburne"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Coffee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Colbert"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Conecuh"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Coosa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Autauga"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Covington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Crenshaw"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cullman"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dale"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dallas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "De Kalb"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Elmore"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Escambia"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Etowah"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fayette"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Baldwin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Franklin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Geneva"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Greene"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hale"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Henry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Houston"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jackson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jefferson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lamar"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lauderdale"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Barbour"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lawrence"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Limestone"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lowndes"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Macon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Madison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marengo"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.47_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marion"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.48_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marshall"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.49_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mobile"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bibb"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.50_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Monroe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.51_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Montgomery"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.52_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Morgan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.53_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Perry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.54_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pickens"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.55_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pike"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.56_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Randolph"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.57_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Russell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.58_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saint Clair"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.59_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Shelby"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Blount"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.60_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sumter"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.61_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Talladega"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.62_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tallapoosa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.63_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tuscaloosa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.64_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Walker"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.65_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.66_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wilcox"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.67_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Winston"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bullock"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Butler"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Calhoun"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chambers"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clay"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Collier"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Columbia"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Desoto"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dixie"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Duval"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Escambia"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Flagler"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Franklin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gadsden"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Alachua"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gilchrist"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Glades"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gulf"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hamilton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hardee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hendry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hernando"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Highlands"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hillsborough"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Holmes"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Baker"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Indian River"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jackson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jefferson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lafayette"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lake"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Leon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Levy"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Liberty"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Madison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bay"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Manatee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marion"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Martin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Miami-Dade"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Monroe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Nassau"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Okaloosa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.47_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Okeechobee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.48_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Orange"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.49_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Osceola"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bradford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.50_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Palm Beach"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.51_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pasco"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.52_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pinellas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.53_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Polk"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.54_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Putnam"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.55_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saint Johns"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.56_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saint Lucie"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.57_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Santa Rosa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.58_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sarasota"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.59_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Seminole"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Brevard"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.60_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sumter"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.61_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Suwannee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.62_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Taylor"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.63_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Union"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.64_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Volusia"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.65_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wakulla"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.66_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Walton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.67_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Broward"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Calhoun"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Charlotte"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Citrus"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Florida"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.100_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Miller"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.101_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mitchell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.102_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Monroe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.103_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Montgomery"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.104_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Morgan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.105_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Murray"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.106_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Muscogee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.107_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Newton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.108_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Oconee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.109_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Oglethorpe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Berrien"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.110_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Paulding"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.111_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Peach"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.112_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pickens"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.113_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pierce"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.114_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pike"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.115_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Polk"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.116_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pulaski"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.117_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Putnam"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.118_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Quitman"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.119_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rabun"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bibb"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.120_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Randolph"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.121_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Richmond"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.122_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rockdale"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.123_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Schley"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.124_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Screven"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.125_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Seminole"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.126_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Spalding"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.127_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Stephens"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.128_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Stewart"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.129_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sumter"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bleckley"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.130_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Talbot"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.131_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Taliaferro"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.132_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tattnall"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.133_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Taylor"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.134_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Telfair"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.135_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Terrell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.136_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Thomas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.137_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tift"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.138_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Toombs"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.139_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Towns"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Brantley"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.140_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Treutlen"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.141_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Troup"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.142_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Turner"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.143_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Twiggs"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.144_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Union"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.145_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Upson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.146_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Walker"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.147_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Walton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.148_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ware"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.149_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Warren"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Brooks"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.150_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.151_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wayne"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.152_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Webster"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.153_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wheeler"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.154_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "White"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.155_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Whitfield"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.156_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wilcox"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.157_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wilkes"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.158_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wilkinson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.159_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Worth"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bryan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bulloch"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Burke"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Butts"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Calhoun"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Appling"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Camden"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Candler"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Carroll"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Catoosa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Charlton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chatham"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chattahoochee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chattooga"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cherokee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clarke"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Atkinson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clay"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clayton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clinch"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cobb"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Coffee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Colquitt"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Columbia"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cook"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Coweta"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Crawford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bacon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Crisp"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dade"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dawson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Decatur"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "DeKalb"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dodge"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dooly"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.47_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dougherty"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.48_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Douglas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.49_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Early"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Baker"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.50_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Echols"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.51_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Effingham"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.52_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Elbert"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.53_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Emanuel"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.54_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Evans"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.55_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fannin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.56_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fayette"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.57_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Floyd"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.58_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Forsyth"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.59_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Franklin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Baldwin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.60_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fulton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.61_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gilmer"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.62_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Glascock"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.63_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Glynn"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.64_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gordon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.65_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grady"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.66_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Greene"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.67_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gwinnett"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.68_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Habersham"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.69_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hall"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Banks"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.70_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hancock"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.71_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Haralson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.72_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Harris"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.73_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hart"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.74_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Heard"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.75_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Henry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.76_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Houston"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.77_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Irwin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.78_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jackson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.79_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jasper"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Barrow"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.80_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jeff Davis"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.81_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jefferson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.82_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jenkins"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.83_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Johnson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.84_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jones"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.85_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lamar"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.86_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lanier"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.87_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Laurens"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.88_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.89_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Liberty"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bartow"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.90_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lincoln"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.91_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Long"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.92_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lowndes"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.93_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lumpkin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.94_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Macon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.95_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Madison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.96_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marion"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.97_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "McDuffie"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.98_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "McIntosh"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.99_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Meriwether"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ben Hill"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Georgia"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.12.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hawaii"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.12.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Honolulu"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.12.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kalawao"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.12.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kauai"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.12.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Maui"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hawaii"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bonneville"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Boundary"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Butte"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Camas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Canyon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Caribou"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cassia"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clark"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clearwater"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Custer"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ada"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Elmore"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Franklin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fremont"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gem"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gooding"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Idaho"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jefferson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jerome"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kootenai"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Latah"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Adams"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lemhi"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lewis"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lincoln"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Madison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Minidoka"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Nez Perce"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Oneida"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Owyhee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Payette"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Power"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bannock"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Shoshone"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Teton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Twin Falls"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Valley"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bear Lake"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Benewah"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bingham"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Blaine"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Boise"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bonner"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Idaho"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.100_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Will"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.101_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Williamson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.102_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Winnebago"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.103_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Woodford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Champaign"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Christian"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clark"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clay"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clinton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Coles"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cook"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Crawford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cumberland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "De Kalb"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Adams"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "De Witt"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Douglas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dupage"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Edgar"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Edwards"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Effingham"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fayette"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Franklin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fulton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Alexander"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gallatin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Greene"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grundy"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hamilton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hancock"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hardin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Henderson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Henry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Iroquois"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jackson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bond"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jasper"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jefferson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jersey"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jo Daviess"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Johnson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kane"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kankakee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.47_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kendall"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.48_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Knox"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.49_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "La Salle"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Boone"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.50_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lake"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.51_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lake Michigan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.52_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lawrence"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.53_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.54_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Livingston"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.55_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Logan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.56_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Macon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.57_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Macoupin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.58_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Madison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.59_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marion"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Brown"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.60_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marshall"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.61_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mason"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.62_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Massac"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.63_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "McDonough"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.64_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "McHenry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.65_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "McLean"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.66_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Menard"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.67_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mercer"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.68_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Monroe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.69_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Montgomery"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bureau"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.70_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Morgan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.71_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Moultrie"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.72_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ogle"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.73_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Peoria"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.74_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Perry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.75_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Piatt"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.76_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pike"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.77_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pope"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.78_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pulaski"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.79_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Putnam"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Calhoun"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.80_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Randolph"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.81_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Richland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.82_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rock Island"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.83_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saint Clair"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.84_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saline"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.85_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sangamon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.86_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Schuyler"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.87_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Scott"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.88_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Shelby"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.89_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Stark"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Carroll"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.90_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Stephenson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.91_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tazewell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.92_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Union"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.93_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Vermilion"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.94_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wabash"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.95_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Warren"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.96_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.97_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wayne"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.98_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "White"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.99_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Whiteside"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cass"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Illinois"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clark"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clay"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clinton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Crawford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Daviess"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "De Kalb"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dearborn"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Decatur"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Delaware"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dubois"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Adams"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Elkhart"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fayette"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Floyd"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fountain"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Franklin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fulton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gibson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grant"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Greene"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hamilton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Allen"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hancock"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Harrison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hendricks"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Henry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Howard"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Huntington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jackson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jasper"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jay"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jefferson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bartholomew"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jennings"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Johnson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Knox"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kosciusko"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "LaGrange"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lake"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lake Michigan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.47_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "LaPorte"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.48_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lawrence"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.49_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Madison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Benton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.50_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marion"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.51_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marshall"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.52_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Martin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.53_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Miami"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.54_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Monroe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.55_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Montgomery"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.56_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Morgan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.57_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Newton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.58_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Noble"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.59_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ohio"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Blackford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.60_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Orange"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.61_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Owen"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.62_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Parke"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.63_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Perry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.64_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pike"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.65_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Porter"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.66_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Posey"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.67_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pulaski"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.68_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Putnam"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.69_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Randolph"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Boone"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.70_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ripley"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.71_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rush"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.72_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saint Joseph"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.73_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Scott"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.74_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Shelby"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.75_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Spencer"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.76_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Starke"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.77_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Steuben"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.78_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sullivan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.79_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Switzerland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Brown"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.80_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tippecanoe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.81_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tipton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.82_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Union"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.83_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Vanderburgh"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.84_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Vermillion"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.85_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Vigo"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.86_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wabash"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.87_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Warren"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.88_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Warrick"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.89_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Carroll"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.90_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wayne"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.91_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wells"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.92_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "White"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.93_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Whitley"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cass"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Indiana"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Buchanan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Buena Vista"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Butler"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Calhoun"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Carroll"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cass"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cedar"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cerro Gordo"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cherokee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chickasaw"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Adair"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clarke"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clay"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clayton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clinton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Crawford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dallas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Davis"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Decatur"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Delaware"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Des Moines"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Adams"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dickinson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dubuque"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Emmet"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fayette"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Floyd"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Franklin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fremont"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Greene"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grundy"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Guthrie"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Allamakee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hamilton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hancock"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hardin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Harrison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Henry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Howard"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Humboldt"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.47_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ida"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.48_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Iowa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.49_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jackson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Appanoose"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.50_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jasper"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.51_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jefferson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.52_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Johnson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.53_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jones"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.54_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Keokuk"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.55_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kossuth"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.56_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.57_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Linn"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.58_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Louisa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.59_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lucas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Audubon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.60_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lyon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.61_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Madison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.62_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mahaska"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.63_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marion"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.64_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marshall"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.65_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mills"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.66_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mitchell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.67_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Monona"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.68_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Monroe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.69_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Montgomery"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Benton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.70_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Muscatine"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.71_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "O'Brien"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.72_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Osceola"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.73_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Page"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.74_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Palo Alto"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.75_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Plymouth"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.76_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pocahontas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.77_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Polk"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.78_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pottawattamie"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.79_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Poweshiek"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Black Hawk"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.80_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ringgold"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.81_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sac"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.82_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Scott"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.83_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Shelby"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.84_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sioux"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.85_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Story"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.86_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tama"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.87_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Taylor"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.88_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Union"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.89_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Van Buren"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Boone"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.90_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wapello"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.91_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Warren"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.92_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.93_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wayne"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.94_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Webster"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.95_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Winnebago"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.96_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Winneshiek"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.97_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Woodbury"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.98_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Worth"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.99_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wright"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bremer"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Iowa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.100_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wallace"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.101_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.102_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wichita"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.103_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wilson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.104_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Woodson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.105_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wyandotte"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chautauqua"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cherokee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cheyenne"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clark"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clay"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cloud"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Coffey"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Comanche"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cowley"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Crawford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Allen"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Decatur"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dickinson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Doniphan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Douglas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Edwards"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Elk"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ellis"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ellsworth"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Finney"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Anderson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Franklin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Geary"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gove"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Graham"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grant"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gray"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Greeley"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Greenwood"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hamilton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Harper"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Atchison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Harvey"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Haskell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hodgeman"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jackson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jefferson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jewell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Johnson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.47_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kearny"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.48_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kingman"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.49_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kiowa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Barber"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.50_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Labette"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.51_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lane"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.52_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Leavenworth"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.53_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lincoln"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.54_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Linn"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.55_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Logan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.56_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lyon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.57_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marion"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.58_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marshall"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.59_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "McPherson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Barton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.60_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Meade"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.61_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Miami"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.62_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mitchell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.63_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Montgomery"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.64_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Morris"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.65_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Morton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.66_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Nemaha"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.67_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Neosho"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.68_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ness"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.69_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Norton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bourbon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.70_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Osage"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.71_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Osborne"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.72_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ottawa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.73_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pawnee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.74_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Phillips"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.75_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pottawatomie"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.76_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pratt"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.77_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rawlins"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.78_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Reno"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.79_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Republic"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Brown"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.80_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rice"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.81_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Riley"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.82_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rooks"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.83_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rush"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.84_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Russell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.85_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saline"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.86_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Scott"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.87_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sedgwick"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.88_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Seward"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.89_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Shawnee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Butler"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.90_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sheridan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.91_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sherman"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.92_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Smith"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.93_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Stafford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.94_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Stanton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.95_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Stevens"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.96_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sumner"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.97_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Thomas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.98_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Trego"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.99_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wabaunsee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chase"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kansas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.100_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pulaski"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.101_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Robertson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.102_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rockcastle"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.103_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rowan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.104_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Russell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.105_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Scott"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.106_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Shelby"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.107_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Simpson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.108_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Spencer"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.109_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Taylor"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Boyd"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.110_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Todd"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.111_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Trigg"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.112_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Trimble"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.113_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Union"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.114_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Warren"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.115_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.116_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wayne"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.117_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Webster"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.118_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Whitley"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.119_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wolfe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Boyle"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.120_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Woodford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bracken"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Breathitt"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Breckinridge"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bullitt"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Butler"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Caldwell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Calloway"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Campbell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Adair"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Carlisle"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Carroll"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Carter"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Casey"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Christian"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clark"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clay"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clinton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Crittenden"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cumberland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Allen"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Daviess"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Edmonson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Elliott"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Estill"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fayette"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fleming"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Floyd"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Franklin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fulton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gallatin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Anderson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Garrard"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grant"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Graves"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grayson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Green"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Greenup"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hancock"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.47_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hardin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.48_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Harlan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.49_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Harrison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ballard"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.50_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hart"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.51_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Henderson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.52_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Henry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.53_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hickman"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.54_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hopkins"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.55_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jackson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.56_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jefferson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.57_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jessamine"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.58_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Johnson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.59_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kenton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Barren"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.60_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Knott"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.61_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Knox"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.62_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Larue"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.63_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Laurel"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.64_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lawrence"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.65_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.66_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Leslie"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.67_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Letcher"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.68_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lewis"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.69_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lincoln"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bath"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.70_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Livingston"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.71_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Logan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.72_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lyon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.73_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Madison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.74_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Magoffin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.75_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marion"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.76_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marshall"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.77_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Martin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.78_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mason"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.79_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "McCracken"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.80_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "McCreary"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.81_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "McLean"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.82_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Meade"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.83_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Menifee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.84_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mercer"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.85_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Metcalfe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.86_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Monroe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.87_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Montgomery"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.88_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Morgan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.89_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Muhlenberg"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Boone"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.90_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Nelson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.91_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Nicholas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.92_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ohio"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.93_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Oldham"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.94_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Owen"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.95_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Owsley"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.96_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pendleton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.97_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Perry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.98_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pike"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.99_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Powell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bourbon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kentucky"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Calcasieu"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Caldwell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cameron"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Catahoula"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Claiborne"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Concordia"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "De Soto"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "East Baton Rouge"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "East Carroll"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "East Feliciana"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Acadia"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Evangeline"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Franklin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grant"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Iberia"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Iberville"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jackson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jefferson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jefferson Davis"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "La Salle"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lafayette"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Allen"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lafourche"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lincoln"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Livingston"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Madison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Morehouse"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Natchitoches"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Orleans"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ouachita"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Plaquemines"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pointe Coupee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ascension"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rapides"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Red River"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Richland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sabine"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saint Bernard"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saint Charles"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saint Helena"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.47_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saint James"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.48_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saint John the Baptist"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.49_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saint Landry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Assumption"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.50_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saint Martin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.51_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saint Mary"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.52_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saint Tammany"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.53_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tangipahoa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.54_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tensas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.55_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Terrebonne"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.56_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Union"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.57_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Vermilion"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.58_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Vernon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.59_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Avoyelles"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.60_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Webster"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.61_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "West Baton Rouge"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.62_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "West Carroll"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.63_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "West Feliciana"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.64_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Winn"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Beauregard"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bienville"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bossier"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Caddo"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Louisiana"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Alabama"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.2.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Juneau"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.2.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kenai Peninsula"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.2.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ketchikan Gateway"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.2.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kodiak Island"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.2.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lake and Peninsula"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.2.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Matanuska-Susitna"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.2.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Nome"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.2.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "North Slope"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.2.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Northwest Arctic"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.2.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Prince of Wales-Outer Ketchi"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.2.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Aleutians East"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.2.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sitka"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.2.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Skagway-Yakutat-Angoon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.2.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Southeast Fairbanks"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.2.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Valdez-Cordova"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.2.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wade Hampton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.2.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wrangell-Petersburg"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.2.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Yukon-Koyukuk"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.2.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Aleutians West"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.2.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Anchorage"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.2.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bethel"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.2.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bristol Bay"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.2.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Denali"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.2.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dillingham"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.2.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fairbanks North Star"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.2.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Haines"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.20.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Penobscot"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.20.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Piscataquis"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.20.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sagadahoc"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.20.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Somerset"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.20.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Waldo"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.20.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.20.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "York"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.20.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Androscoggin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.20.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Aroostook"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.20.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cumberland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.20.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Franklin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.20.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hancock"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.20.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kennebec"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.20.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Knox"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.20.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lincoln"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.20.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Oxford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Maine"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.21.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Frederick"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.21.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Garrett"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.21.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Harford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.21.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Howard"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.21.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kent"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.21.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Montgomery"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.21.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Prince George's"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.21.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Queen Anne's"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.21.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saint Mary's"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.21.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Somerset"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.21.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Allegany"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.21.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Talbot"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.21.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.21.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wicomico"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.21.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Worcester"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.21.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Anne Arundel"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.21.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Baltimore"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.21.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Calvert"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.21.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Caroline"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.21.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Carroll"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.21.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cecil"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.21.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Charles"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.21.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dorchester"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Maryland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.22.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Nantucket"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.22.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Norfolk"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.22.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Plymouth"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.22.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Suffolk"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.22.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Worcester"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.22.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Barnstable"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.22.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Berkshire"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.22.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bristol"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.22.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dukes"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.22.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Essex"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.22.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Franklin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.22.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hampden"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.22.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hampshire"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.22.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Middlesex"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Massachusetts"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Benzie"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Berrien"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Branch"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Calhoun"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cass"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Charlevoix"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cheboygan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chippewa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clare"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clinton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Alcona"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Crawford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Delta"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dickinson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Eaton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Emmet"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Genesee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gladwin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gogebic"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grand Traverse"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gratiot"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Alger"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hillsdale"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Houghton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Huron"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ingham"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ionia"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Iosco"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Iron"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Isabella"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jackson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kalamazoo"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Allegan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kalkaska"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kent"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Keweenaw"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lake"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lake Hurron"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lake Michigan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lake St. Clair"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.47_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lake Superior"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.48_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lapeer"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.49_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Leelanau"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Alpena"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.50_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lenawee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.51_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Livingston"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.52_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Luce"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.53_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mackinac"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.54_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Macomb"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.55_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Manistee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.56_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marquette"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.57_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mason"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.58_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mecosta"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.59_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Menominee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Antrim"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.60_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Midland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.61_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Missaukee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.62_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Monroe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.63_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Montcalm"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.64_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Montmorency"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.65_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Muskegon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.66_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Newaygo"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.67_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Oakland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.68_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Oceana"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.69_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ogemaw"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Arenac"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.70_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ontonagon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.71_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Osceola"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.72_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Oscoda"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.73_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Otsego"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.74_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ottawa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.75_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Presque Isle"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.76_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Roscommon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.77_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saginaw"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.78_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saint Clair"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.79_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saint Joseph"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Baraga"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.80_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sanilac"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.81_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Schoolcraft"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.82_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Shiawassee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.83_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tuscola"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.84_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Van Buren"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.85_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washtenaw"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.86_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wayne"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.87_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wexford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Barry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bay"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Michigan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Carver"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cass"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chippewa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chisago"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clay"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clearwater"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cook"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cottonwood"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Crow Wing"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dakota"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Aitkin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dodge"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Douglas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Faribault"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fillmore"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Freeborn"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Goodhue"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grant"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hennepin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Houston"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hubbard"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Anoka"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Isanti"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Itasca"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jackson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kanabec"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kandiyohi"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kittson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Koochiching"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lac qui Parle"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lake"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lake of the Woods"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Becker"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lake Superior"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Le Sueur"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lincoln"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lyon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mahnomen"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marshall"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Martin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.47_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "McLeod"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.48_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Meeker"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.49_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mille Lacs"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Beltrami"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.50_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Morrison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.51_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mower"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.52_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Murray"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.53_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Nicollet"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.54_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Nobles"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.55_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Norman"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.56_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Olmsted"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.57_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Otter Tail"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.58_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pennington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.59_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pine"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Benton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.60_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pipestone"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.61_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Polk"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.62_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pope"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.63_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ramsey"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.64_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Red Lake"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.65_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Redwood"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.66_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Renville"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.67_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rice"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.68_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rock"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.69_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Roseau"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Big Stone"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.70_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saint Louis"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.71_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Scott"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.72_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sherburne"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.73_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sibley"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.74_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Stearns"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.75_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Steele"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.76_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Stevens"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.77_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Swift"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.78_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Todd"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.79_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Traverse"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Blue Earth"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.80_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wabasha"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.81_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wadena"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.82_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Waseca"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.83_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.84_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Watonwan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.85_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wilkin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.86_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Winona"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.87_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wright"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.88_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Yellow Medicine"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Brown"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Carlton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Minnesota"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Choctaw"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Claiborne"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clarke"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clay"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Coahoma"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Copiah"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Covington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Desoto"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Forrest"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Franklin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Adams"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "George"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Greene"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grenada"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hancock"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Harrison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hinds"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Holmes"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Humphreys"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Issaquena"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Itawamba"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Alcorn"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jackson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jasper"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jefferson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jefferson Davis"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jones"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kemper"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lafayette"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lamar"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lauderdale"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lawrence"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Amite"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Leake"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Leflore"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lincoln"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lowndes"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Madison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marion"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.47_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marshall"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.48_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Monroe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.49_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Montgomery"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Attala"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.50_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Neshoba"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.51_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Newton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.52_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Noxubee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.53_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Oktibbeha"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.54_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Panola"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.55_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pearl River"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.56_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Perry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.57_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pike"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.58_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pontotoc"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.59_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Prentiss"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Benton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.60_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Quitman"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.61_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rankin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.62_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Scott"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.63_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sharkey"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.64_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Simpson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.65_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Smith"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.66_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Stone"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.67_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sunflower"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.68_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tallahatchie"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.69_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tate"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bolivar"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.70_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tippah"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.71_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tishomingo"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.72_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tunica"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.73_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Union"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.74_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Walthall"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.75_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Warren"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.76_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.77_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wayne"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.78_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Webster"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.79_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wilkinson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Calhoun"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.80_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Winston"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.81_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Yalobusha"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.82_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Yazoo"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Carroll"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chickasaw"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mississippi"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.100_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Scott"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.101_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Shannon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.102_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Shelby"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.103_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Stoddard"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.104_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Stone"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.105_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sullivan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.106_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Taney"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.107_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Texas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.108_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Vernon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.109_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Warren"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Boone"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.110_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.111_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wayne"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.112_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Webster"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.113_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Worth"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.114_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wright"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Buchanan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Butler"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Caldwell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Callaway"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Camden"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cape Girardeau"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Carroll"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Carter"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cass"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Adair"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cedar"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chariton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Christian"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clark"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clay"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clinton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cole"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cooper"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Crawford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dade"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Andrew"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dallas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Daviess"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "De Kalb"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dent"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Douglas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dunklin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Franklin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gasconade"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gentry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Greene"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Atchison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grundy"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Harrison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Henry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hickory"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Holt"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Howard"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Howell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.47_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Iron"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.48_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jackson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.49_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jasper"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Audrain"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.50_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jefferson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.51_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Johnson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.52_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Knox"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.53_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Laclede"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.54_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lafayette"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.55_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lawrence"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.56_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lewis"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.57_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lincoln"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.58_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Linn"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.59_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Livingston"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Barry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.60_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Macon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.61_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Madison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.62_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Maries"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.63_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marion"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.64_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "McDonald"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.65_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mercer"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.66_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Miller"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.67_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mississippi"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.68_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Moniteau"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.69_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Monroe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Barton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.70_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Montgomery"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.71_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Morgan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.72_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "New Madrid"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.73_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Newton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.74_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Nodaway"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.75_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Oregon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.76_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Osage"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.77_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ozark"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.78_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pemiscot"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.79_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Perry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bates"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.80_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pettis"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.81_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Phelps"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.82_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pike"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.83_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Platte"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.84_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Polk"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.85_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pulaski"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.86_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Putnam"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.87_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ralls"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.88_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Randolph"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.89_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ray"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Benton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.90_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Reynolds"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.91_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ripley"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.92_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saint Charles"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.93_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saint Clair"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.94_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saint Francois"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.95_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saint Louis"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.96_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sainte Genevieve"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.97_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saline"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.98_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Schuyler"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.99_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Scotland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bollinger"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Missouri"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Daniels"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dawson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Deer Lodge"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fallon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fergus"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Flathead"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gallatin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Garfield"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Glacier"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Golden Valley"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Beaverhead"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Granite"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hill"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jefferson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Judith Basin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lake"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lewis and Clark"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Liberty"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lincoln"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Madison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "McCone"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Big Horn"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Meagher"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mineral"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Missoula"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Musselshell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Park"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Petroleum"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Phillips"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pondera"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Powder River"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Powell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Blaine"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Prairie"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ravalli"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Richland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Roosevelt"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rosebud"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sanders"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sheridan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.47_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Silver Bow"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.48_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Stillwater"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.49_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sweet Grass"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Broadwater"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.50_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Teton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.51_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Toole"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.52_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Treasure"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.53_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Valley"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.54_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wheatland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.55_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wibaux"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.56_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Yellowstone"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Carbon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Carter"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cascade"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chouteau"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Custer"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Montana"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Buffalo"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Burt"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Butler"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cass"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cedar"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chase"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cherry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cheyenne"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clay"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Colfax"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Adams"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cuming"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Custer"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dakota"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dawes"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dawson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Deuel"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dixon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dodge"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Douglas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dundy"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Antelope"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fillmore"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Franklin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Frontier"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Furnas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gage"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Garden"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Garfield"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gosper"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grant"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Greeley"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Arthur"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hall"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hamilton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Harlan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hayes"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hitchcock"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Holt"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hooker"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.47_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Howard"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.48_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jefferson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.49_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Johnson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Banner"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.50_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kearney"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.51_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Keith"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.52_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Keya Paha"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.53_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kimball"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.54_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Knox"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.55_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lancaster"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.56_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lincoln"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.57_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Logan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.58_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Loup"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.59_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Madison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Blaine"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.60_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "McPherson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.61_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Merrick"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.62_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Morrill"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.63_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Nance"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.64_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Nemaha"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.65_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Nuckolls"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.66_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Otoe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.67_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pawnee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.68_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Perkins"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.69_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Phelps"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Boone"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.70_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pierce"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.71_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Platte"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.72_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Polk"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.73_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Red Willow"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.74_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Richardson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.75_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rock"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.76_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saline"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.77_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sarpy"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.78_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saunders"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.79_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Scotts Bluff"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Box Butte"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.80_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Seward"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.81_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sheridan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.82_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sherman"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.83_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sioux"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.84_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Stanton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.85_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Thayer"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.86_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Thomas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.87_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Thurston"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.88_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Valley"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.89_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Boyd"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.90_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wayne"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.91_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Webster"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.92_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wheeler"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.93_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "York"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Brown"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Nebraska"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.29.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lincoln"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.29.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lyon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.29.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mineral"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.29.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Nye"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.29.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pershing"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.29.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Storey"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.29.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washoe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.29.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "White Pine"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.29.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Carson City"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.29.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Churchill"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.29.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clark"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.29.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Douglas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.29.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Elko"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.29.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Esmeralda"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.29.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Eureka"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.29.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Humboldt"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.29.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lander"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Nevada"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Alaska"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.3.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Navajo"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.3.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pima"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.3.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pinal"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.3.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Santa Cruz"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.3.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Yavapai"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.3.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Yuma"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.3.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Apache"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.3.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cochise"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.3.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Coconino"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.3.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gila"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.3.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Graham"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.3.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Greenlee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.3.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "La Paz"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.3.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Maricopa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.3.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mohave"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.30.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sullivan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.30.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Belknap"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.30.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Carroll"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.30.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cheshire"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.30.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Coos"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.30.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grafton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.30.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hillsborough"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.30.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Merrimack"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.30.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rockingham"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.30.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Strafford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "New Hampshire"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.31.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hunterdon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.31.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mercer"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.31.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Middlesex"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.31.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Monmouth"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.31.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Morris"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.31.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ocean"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.31.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Passaic"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.31.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Salem"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.31.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Somerset"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.31.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sussex"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.31.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Atlantic"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.31.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Union"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.31.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Warren"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.31.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bergen"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.31.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Burlington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.31.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Camden"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.31.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cape May"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.31.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cumberland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.31.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Essex"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.31.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gloucester"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.31.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hudson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "New Jersey"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grant"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Guadalupe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Harding"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hidalgo"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lea"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lincoln"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Los Alamos"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Luna"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "McKinley"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mora"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bernalillo"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Otero"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Quay"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rio Arriba"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Roosevelt"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "San Juan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "San Miguel"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sandoval"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Santa Fe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sierra"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Socorro"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Catron"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Taos"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Torrance"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Union"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Valencia"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chaves"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cibola"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Colfax"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Curry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Debaca"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dona Ana"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Eddy"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "New Mexico"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clinton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Columbia"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cortland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Delaware"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dutchess"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Erie"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Essex"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Franklin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fulton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Genesee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Albany"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Greene"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hamilton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Herkimer"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jefferson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kings"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lake Ontario"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lewis"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Livingston"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Madison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Monroe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Allegany"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Montgomery"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Nassau"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "New York"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Niagara"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Oneida"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Onondaga"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ontario"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Orange"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Orleans"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Oswego"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bronx"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Otsego"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Putnam"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Queens"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rensselaer"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Richmond"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rockland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saint Lawrence"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.47_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saratoga"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.48_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Schenectady"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.49_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Schoharie"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Broome"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.50_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Schuyler"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.51_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Seneca"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.52_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Steuben"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.53_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Suffolk"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.54_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sullivan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.55_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tioga"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.56_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tompkins"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.57_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ulster"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.58_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Warren"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.59_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cattaraugus"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.60_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wayne"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.61_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Westchester"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.62_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wyoming"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.63_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Yates"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cayuga"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chautauqua"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chemung"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chenango"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "New York"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.100_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Yancey"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Brunswick"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Buncombe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Burke"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cabarrus"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Caldwell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Camden"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Carteret"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Caswell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Catawba"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chatham"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Alamance"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cherokee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chowan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clay"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cleveland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Columbus"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Craven"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cumberland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Currituck"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dare"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Davidson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Alexander"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Davie"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Duplin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Durham"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Edgecombe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Forsyth"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Franklin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gaston"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gates"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Graham"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Granville"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Alleghany"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Greene"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Guilford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Halifax"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Harnett"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Haywood"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Henderson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hertford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.47_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hoke"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.48_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hyde"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.49_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Iredell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Anson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.50_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jackson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.51_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Johnston"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.52_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jones"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.53_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.54_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lenoir"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.55_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lincoln"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.56_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Macon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.57_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Madison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.58_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Martin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.59_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "McDowell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ashe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.60_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mecklenburg"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.61_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mitchell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.62_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Montgomery"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.63_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Moore"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.64_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Nash"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.65_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "New Hanover"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.66_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Northampton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.67_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Onslow"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.68_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Orange"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.69_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pamlico"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Avery"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.70_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pasquotank"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.71_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pender"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.72_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Perquimans"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.73_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Person"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.74_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pitt"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.75_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Polk"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.76_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Randolph"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.77_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Richmond"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.78_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Robeson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.79_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rockingham"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Beaufort"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.80_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rowan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.81_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rutherford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.82_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sampson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.83_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Scotland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.84_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Stanly"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.85_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Stokes"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.86_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Surry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.87_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Swain"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.88_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Transylvania"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.89_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tyrrell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bertie"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.90_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Union"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.91_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Vance"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.92_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wake"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.93_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Warren"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.94_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.95_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Watauga"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.96_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wayne"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.97_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wilkes"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.98_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wilson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.99_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Yadkin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bladen"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "North Carolina"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cavalier"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dickey"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Divide"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dunn"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Eddy"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Emmons"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Foster"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Golden Valley"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grand Forks"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grant"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Adams"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Griggs"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hettinger"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kidder"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lamoure"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Logan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "McHenry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "McIntosh"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "McKenzie"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "McLean"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mercer"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Barnes"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Morton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mountrail"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Nelson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Oliver"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pembina"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pierce"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ramsey"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ransom"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Renville"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Richland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Benson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rolette"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sargent"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sheridan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sioux"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Slope"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Stark"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Steele"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.47_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Stutsman"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.48_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Towner"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.49_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Traill"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Billings"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.50_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Walsh"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.51_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ward"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.52_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wells"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.53_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Williams"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bottineau"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bowman"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Burke"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Burleigh"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cass"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "North Dakota"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Carroll"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Champaign"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clark"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clermont"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clinton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Columbiana"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Coshocton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Crawford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cuyahoga"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Darke"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Adams"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Defiance"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Delaware"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Erie"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fairfield"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fayette"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Franklin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fulton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gallia"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Geauga"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Greene"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Allen"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Guernsey"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hamilton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hancock"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hardin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Harrison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Henry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Highland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hocking"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Holmes"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Huron"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ashland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jackson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jefferson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Knox"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lake"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lake Erie"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lawrence"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Licking"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.47_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Logan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.48_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lorain"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.49_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lucas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ashtabula"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.50_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Madison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.51_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mahoning"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.52_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marion"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.53_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Medina"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.54_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Meigs"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.55_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mercer"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.56_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Miami"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.57_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Monroe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.58_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Montgomery"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.59_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Morgan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Athens"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.60_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Morrow"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.61_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Muskingum"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.62_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Noble"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.63_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ottawa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.64_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Paulding"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.65_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Perry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.66_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pickaway"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.67_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pike"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.68_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Portage"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.69_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Preble"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Auglaize"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.70_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Putnam"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.71_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Richland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.72_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ross"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.73_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sandusky"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.74_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Scioto"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.75_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Seneca"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.76_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Shelby"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.77_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Stark"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.78_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Summit"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.79_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Trumbull"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Belmont"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.80_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tuscarawas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.81_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Union"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.82_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Van Wert"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.83_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Vinton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.84_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Warren"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.85_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.86_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wayne"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.87_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Williams"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.88_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wood"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.89_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wyandot"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Brown"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Butler"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ohio"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Carter"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cherokee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Choctaw"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cimarron"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cleveland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Coal"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Comanche"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cotton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Craig"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Creek"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Adair"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Custer"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Delaware"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dewey"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ellis"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Garfield"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Garvin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grady"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grant"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Greer"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Harmon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Alfalfa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Harper"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Haskell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hughes"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jackson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jefferson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Johnston"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kay"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kingfisher"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kiowa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Latimer"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Atoka"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Le Flore"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lincoln"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Logan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Love"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Major"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marshall"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mayes"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.47_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "McClain"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.48_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "McCurtain"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.49_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "McIntosh"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Beaver"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.50_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Murray"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.51_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Muskogee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.52_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Noble"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.53_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Nowata"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.54_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Okfuskee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.55_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Oklahoma"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.56_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Okmulgee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.57_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Osage"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.58_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ottawa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.59_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pawnee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Beckham"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.60_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Payne"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.61_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pittsburg"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.62_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pontotoc"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.63_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pottawatomie"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.64_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pushmataha"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.65_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Roger Mills"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.66_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rogers"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.67_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Seminole"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.68_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sequoyah"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.69_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Stephens"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Blaine"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.70_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Texas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.71_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tillman"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.72_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tulsa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.73_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wagoner"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.74_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.75_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washita"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.76_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Woods"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.77_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Woodward"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bryan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Caddo"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Canadian"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Oklahoma"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Douglas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gilliam"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grant"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Harney"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hood River"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jackson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jefferson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Josephine"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Klamath"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lake"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Baker"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lane"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lincoln"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Linn"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Malheur"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marion"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Morrow"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Multnomah"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Polk"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sherman"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tillamook"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Benton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Umatilla"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Union"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wallowa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wasco"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wheeler"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Yamhill"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clackamas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clatsop"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Columbia"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Coos"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Crook"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Curry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Deschutes"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Oregon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Butler"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cambria"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cameron"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Carbon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Centre"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chester"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clarion"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clearfield"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clinton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Columbia"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Adams"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Crawford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cumberland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dauphin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Delaware"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Elk"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Erie"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fayette"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Forest"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Franklin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fulton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Allegheny"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Greene"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Huntingdon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Indiana"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jefferson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Juniata"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lackawanna"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lancaster"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lawrence"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lebanon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lehigh"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Armstrong"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Luzerne"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lycoming"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mc Kean"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mercer"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mifflin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Monroe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Montgomery"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.47_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Montour"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.48_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Northampton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.49_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Northumberland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Beaver"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.50_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Perry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.51_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Philadelphia"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.52_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pike"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.53_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Potter"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.54_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Schuylkill"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.55_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Snyder"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.56_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Somerset"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.57_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sullivan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.58_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Susquehanna"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.59_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tioga"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bedford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.60_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Union"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.61_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Venango"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.62_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Warren"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.63_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.64_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wayne"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.65_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Westmoreland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.66_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wyoming"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.67_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "York"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Berks"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Blair"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bradford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bucks"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pennsylvania"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Arizona"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clark"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clay"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cleburne"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cleveland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Columbia"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Conway"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Craighead"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Crawford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Crittenden"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cross"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Arkansas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dallas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Desha"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Drew"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Faulkner"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Franklin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fulton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Garland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grant"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Greene"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hempstead"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ashley"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hot Spring"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Howard"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Independence"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Izard"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jackson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jefferson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Johnson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lafayette"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lawrence"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Baxter"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lincoln"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Little River"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Logan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lonoke"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Madison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marion"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Miller"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.47_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mississippi"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.48_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Monroe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.49_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Montgomery"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Benton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.50_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Nevada"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.51_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Newton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.52_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ouachita"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.53_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Perry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.54_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Phillips"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.55_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pike"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.56_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Poinsett"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.57_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Polk"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.58_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pope"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.59_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Prairie"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Boone"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.60_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pulaski"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.61_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Randolph"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.62_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saint Francis"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.63_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saline"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.64_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Scott"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.65_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Searcy"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.66_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sebastian"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.67_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sevier"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.68_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sharp"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.69_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Stone"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bradley"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.70_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Union"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.71_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Van Buren"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.72_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.73_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "White"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.74_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Woodruff"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.75_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Yell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Calhoun"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Carroll"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chicot"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.40.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bristol"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.40.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kent"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.40.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Newport"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.40.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Providence"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.40.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rhode Island"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Charleston"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cherokee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chester"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chesterfield"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clarendon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Colleton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Darlington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dillon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dorchester"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Edgefield"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Abbeville"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fairfield"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Florence"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Georgetown"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Greenville"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Greenwood"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hampton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Horry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jasper"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kershaw"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lancaster"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Aiken"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Laurens"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lexington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marion"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marlboro"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "McCormick"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Newberry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Oconee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Orangeburg"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pickens"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Allendale"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Richland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saluda"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Spartanburg"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sumter"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Union"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Williamsburg"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "York"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Anderson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bamberg"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Barnwell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Beaufort"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Berkeley"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Calhoun"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "South Carolina"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Campbell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Charles Mix"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clark"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clay"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Codington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Corson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Custer"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Davison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Day"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Deuel"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Aurora"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dewey"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Douglas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Edmunds"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fall River"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Faulk"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grant"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gregory"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Haakon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hamlin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hand"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Beadle"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hanson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Harding"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hughes"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hutchinson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hyde"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jackson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jerauld"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jones"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kingsbury"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lake"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bennett"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lawrence"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lincoln"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lyman"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marshall"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "McCook"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "McPherson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Meade"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.47_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mellette"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.48_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Miner"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.49_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Minnehaha"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bon Homme"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.50_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Moody"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.51_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pennington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.52_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Perkins"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.53_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Potter"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.54_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Roberts"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.55_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sanborn"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.56_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Shannon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.57_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Spink"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.58_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Stanley"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.59_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sully"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Brookings"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.60_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Todd"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.61_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tripp"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.62_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Turner"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.63_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Union"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.64_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Walworth"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.65_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Yankton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.66_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ziebach"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Brown"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Brule"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Buffalo"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Butte"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "South Dakota"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Carter"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cheatham"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chester"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Claiborne"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clay"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cocke"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Coffee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Crockett"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cumberland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Davidson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Anderson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Decatur"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "DeKalb"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dickson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dyer"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fayette"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fentress"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Franklin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gibson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Giles"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grainger"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bedford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Greene"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grundy"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hamblen"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hamilton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hancock"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hardeman"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hardin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hawkins"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Haywood"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Henderson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Benton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Henry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hickman"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Houston"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Humphreys"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jackson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jefferson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Johnson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.47_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Knox"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.48_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lake"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.49_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lauderdale"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bledsoe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.50_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lawrence"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.51_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lewis"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.52_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lincoln"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.53_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Loudon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.54_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Macon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.55_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Madison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.56_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marion"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.57_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marshall"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.58_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Maury"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.59_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "McMinn"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Blount"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.60_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "McNairy"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.61_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Meigs"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.62_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Monroe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.63_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Montgomery"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.64_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Moore"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.65_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Morgan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.66_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Obion"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.67_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Overton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.68_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Perry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.69_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pickett"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bradley"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.70_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Polk"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.71_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Putnam"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.72_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rhea"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.73_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Roane"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.74_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Robertson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.75_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rutherford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.76_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Scott"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.77_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sequatchie"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.78_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sevier"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.79_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Shelby"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Campbell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.80_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Smith"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.81_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Stewart"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.82_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sullivan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.83_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sumner"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.84_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tipton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.85_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Trousdale"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.86_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Unicoi"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.87_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Union"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.88_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Van Buren"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.89_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Warren"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cannon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.90_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.91_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wayne"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.92_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Weakley"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.93_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "White"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.94_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Williamson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.95_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wilson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Carroll"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tennessee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.100_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hardin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.101_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Harris"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.102_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Harrison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.103_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hartley"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.104_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Haskell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.105_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hays"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.106_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hemphill"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.107_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Henderson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.108_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hidalgo"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.109_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hill"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bandera"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.110_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hockley"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.111_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hood"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.112_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hopkins"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.113_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Houston"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.114_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Howard"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.115_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hudspeth"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.116_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hunt"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.117_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hutchinson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.118_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Irion"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.119_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jack"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bastrop"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.120_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jackson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.121_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jasper"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.122_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jeff Davis"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.123_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jefferson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.124_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jim Hogg"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.125_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jim Wells"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.126_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Johnson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.127_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jones"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.128_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Karnes"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.129_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kaufman"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Baylor"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.130_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kendall"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.131_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kenedy"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.132_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kent"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.133_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kerr"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.134_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kimble"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.135_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "King"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.136_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kinney"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.137_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kleberg"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.138_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Knox"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.139_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "La Salle"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.140_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lamar"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.141_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lamb"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.142_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lampasas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.143_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lavaca"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.144_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.145_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Leon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.146_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Liberty"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.147_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Limestone"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.148_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lipscomb"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.149_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Live Oak"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.150_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Llano"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.151_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Loving"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.152_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lubbock"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.153_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lynn"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.154_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Madison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.155_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marion"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.156_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Martin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.157_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mason"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.158_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Matagorda"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.159_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Maverick"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bexar"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.160_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "McCulloch"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.161_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "McLennan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.162_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "McMullen"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.163_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Medina"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.164_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Menard"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.165_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Midland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.166_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Milam"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.167_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mills"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.168_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mitchell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.169_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Montague"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Blanco"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.170_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Montgomery"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.171_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Moore"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.172_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Morris"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.173_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Motley"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.174_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Nacogdoches"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.175_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Navarro"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.176_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Newton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.177_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Nolan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.178_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Nueces"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.179_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ochiltree"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Borden"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.180_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Oldham"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.181_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Orange"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.182_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Palo Pinto"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.183_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Panola"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.184_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Parker"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.185_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Parmer"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.186_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pecos"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.187_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Polk"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.188_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Potter"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.189_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Presidio"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bosque"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.190_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rains"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.191_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Randall"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.192_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Reagan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.193_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Real"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.194_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Red River"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.195_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Reeves"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.196_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Refugio"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.197_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Roberts"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.198_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Robertson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.199_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rockwall"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bowie"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Anderson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.200_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Runnels"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.201_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rusk"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.202_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sabine"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.203_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "San Augustine"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.204_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "San Jacinto"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.205_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "San Patricio"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.206_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "San Saba"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.207_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Schleicher"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.208_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Scurry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.209_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Shackelford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Brazoria"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.210_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Shelby"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.211_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sherman"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.212_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Smith"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.213_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Somervell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.214_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Starr"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.215_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Stephens"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.216_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sterling"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.217_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Stonewall"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.218_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sutton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.219_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Swisher"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Brazos"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.220_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tarrant"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.221_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Taylor"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.222_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Terrell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.223_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Terry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.224_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Throckmorton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.225_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Titus"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.226_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tom Green"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.227_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Travis"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.228_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Trinity"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.229_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tyler"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Brewster"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.230_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Upshur"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.231_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Upton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.232_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Uvalde"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.233_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Val Verde"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.234_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Van Zandt"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.235_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Victoria"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.236_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Walker"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.237_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Waller"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.238_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ward"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.239_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Briscoe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.240_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Webb"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.241_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wharton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.242_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wheeler"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.243_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wichita"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.244_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wilbarger"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.245_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Willacy"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.246_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Williamson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.247_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wilson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.248_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Winkler"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.249_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wise"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Brooks"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.250_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wood"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.251_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Yoakum"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.252_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Young"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.253_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Zapata"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.254_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Zavala"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Brown"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Burleson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Burnet"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Caldwell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Calhoun"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Andrews"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Callahan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cameron"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Camp"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Carson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cass"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Castro"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chambers"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cherokee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Childress"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clay"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Angelina"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cochran"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Coke"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Coleman"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Collin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Collingsworth"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Colorado"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Comal"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.47_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Comanche"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.48_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Concho"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.49_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cooke"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Aransas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.50_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Coryell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.51_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cottle"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.52_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Crane"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.53_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Crockett"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.54_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Crosby"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.55_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Culberson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.56_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dallam"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.57_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dallas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.58_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dawson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.59_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Deaf Smith"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Archer"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.60_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Delta"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.61_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Denton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.62_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dewitt"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.63_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dickens"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.64_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dimmit"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.65_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Donley"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.66_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Duval"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.67_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Eastland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.68_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ector"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.69_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Edwards"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Armstrong"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.70_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "El Paso"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.71_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ellis"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.72_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Erath"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.73_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Falls"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.74_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fannin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.75_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fayette"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.76_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fisher"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.77_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Floyd"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.78_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Foard"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.79_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fort Bend"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Atascosa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.80_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Franklin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.81_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Freestone"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.82_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Frio"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.83_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gaines"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.84_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Galveston"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.85_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Garza"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.86_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gillespie"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.87_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Glasscock"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.88_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Goliad"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.89_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gonzales"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Austin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.90_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gray"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.91_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grayson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.92_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gregg"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.93_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grimes"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.94_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Guadalupe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.95_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hale"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.96_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hall"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.97_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hamilton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.98_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hansford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.99_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hardeman"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bailey"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Texas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.45.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grand"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.45.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Iron"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.45.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Juab"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.45.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kane"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.45.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Millard"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.45.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Morgan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.45.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Piute"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.45.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rich"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.45.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Salt Lake"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.45.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "San Juan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.45.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Beaver"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.45.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sanpete"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.45.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sevier"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.45.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Summit"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.45.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tooele"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.45.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Uintah"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.45.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Utah"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.45.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wasatch"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.45.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.45.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wayne"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.45.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Weber"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.45.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Box Elder"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.45.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cache"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.45.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Carbon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.45.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Daggett"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.45.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Davis"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.45.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Duchesne"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.45.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Emery"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.45.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Garfield"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Utah"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.46.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Orleans"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.46.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rutland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.46.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.46.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Windham"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.46.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Windsor"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.46.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Addison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.46.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bennington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.46.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Caledonia"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.46.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chittenden"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.46.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Essex"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.46.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Franklin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.46.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grand Isle"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.46.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lamoille"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.46.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Orange"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Vermont"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.100_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Prince Edward"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.101_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Prince George"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.102_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Prince William"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.103_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pulaski"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.104_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Radford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.105_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rappahannock"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.106_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Richmond"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.107_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Roanoke"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.108_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Roanoke City"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.109_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rockbridge"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bath"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.110_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rockingham"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.111_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Russell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.112_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Salem"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.113_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Scott"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.114_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Shenandoah"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.115_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Smyth"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.116_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Southampton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.117_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Spotsylvania"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.118_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Stafford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.119_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Staunton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bedford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.120_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Suffolk"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.121_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Surry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.122_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sussex"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.123_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tazewell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.124_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Virginia Beach"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.125_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Warren"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.126_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.127_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Waynesboro"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.128_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Westmoreland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.129_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Williamsburg"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bedford City"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.130_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Winchester"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.131_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wise"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.132_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wythe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.133_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "York"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Botetourt"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bristol"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Brunswick"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Buchanan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Buckingham"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Buena Vista"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Accomack"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Campbell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Caroline"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Carroll"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Charles City"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Charlotte"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Charlottesville"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chesapeake"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chesterfield"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clarke"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clifton Forge City"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Albemarle"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Colonial Heights"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Covington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Craig"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Culpeper"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cumberland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Danville"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dickenson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dinwiddie"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Emporia"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Essex"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Alexandria"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fairfax"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fairfax City"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Falls Church"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fauquier"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Floyd"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fluvanna"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Franklin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.47_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Frederick"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.48_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fredericksburg"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.49_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Galax"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Alleghany"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.50_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Giles"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.51_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gloucester"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.52_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Goochland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.53_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grayson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.54_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Greene"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.55_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Greensville"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.56_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Halifax"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.57_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hampton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.58_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hanover"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.59_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Harrisonburg"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Amelia"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.60_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Henrico"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.61_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Henry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.62_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Highland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.63_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hopewell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.64_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Isle of Wight"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.65_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "James City"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.66_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "King and Queen"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.67_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "King George"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.68_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "King William"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.69_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lancaster"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Amherst"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.70_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.71_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lexington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.72_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Loudoun"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.73_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Louisa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.74_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lunenburg"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.75_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lynchburg"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.76_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Madison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.77_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Manassas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.78_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Manassas Park"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.79_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Martinsville"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Appomattox"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.80_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mathews"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.81_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mecklenburg"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.82_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Middlesex"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.83_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Montgomery"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.84_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Nelson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.85_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "New Kent"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.86_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Newport News"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.87_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Norfolk"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.88_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Northampton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.89_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Northumberland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Arlington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.90_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Norton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.91_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Nottoway"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.92_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Orange"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.93_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Page"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.94_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Patrick"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.95_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Petersburg"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.96_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pittsylvania"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.97_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Poquoson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.98_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Portsmouth"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.99_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Powhatan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Augusta"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.47_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Virginia"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ferry"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Franklin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Garfield"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grant"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grays Harbor"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Island"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jefferson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "King"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kitsap"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kittitas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Adams"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Klickitat"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lewis"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lincoln"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mason"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Okanogan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pacific"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pend Oreille"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pierce"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "San Juan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Skagit"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Asotin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Skamania"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Snohomish"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Spokane"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Stevens"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Thurston"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wahkiakum"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Walla Walla"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Whatcom"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Whitman"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Yakima"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Benton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chelan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clallam"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clark"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Columbia"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cowlitz"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Douglas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.48_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fayette"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gilmer"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grant"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Greenbrier"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hampshire"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hancock"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hardy"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Harrison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jackson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jefferson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Barbour"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kanawha"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lewis"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lincoln"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Logan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marion"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marshall"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mason"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "McDowell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mercer"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mineral"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Berkeley"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mingo"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Monongalia"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Monroe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Morgan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Nicholas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ohio"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pendleton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pleasants"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pocahontas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Preston"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Boone"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Putnam"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Raleigh"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Randolph"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ritchie"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Roane"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Summers"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Taylor"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.47_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tucker"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.48_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tyler"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.49_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Upshur"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Braxton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.50_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wayne"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.51_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Webster"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.52_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wetzel"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.53_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wirt"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.54_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wood"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.55_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wyoming"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Brooke"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cabell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Calhoun"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clay"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Doddridge"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.49_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "West Virginia"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Arkansas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fresno"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Glenn"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Humboldt"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Imperial"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Inyo"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kern"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kings"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lake"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lassen"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Los Angeles"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Alameda"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Madera"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mariposa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mendocino"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Merced"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Modoc"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mono"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Monterey"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Napa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Nevada"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Alpine"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Orange"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Placer"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Plumas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Riverside"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sacramento"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "San Benito"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "San Bernardino"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "San Diego"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "San Francisco"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "San Joaquin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Amador"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "San Luis Obispo"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "San Mateo"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Santa Barbara"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Santa Clara"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Santa Cruz"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Shasta"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sierra"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.47_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Siskiyou"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.48_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Solano"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.49_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sonoma"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Butte"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.50_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Stanislaus"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.51_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sutter"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.52_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tehama"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.53_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Trinity"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.54_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tulare"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.55_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tuolumne"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.56_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ventura"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.57_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Yolo"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.58_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Yuba"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Calaveras"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Colusa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Contra Costa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Del Norte"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "El Dorado"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clark"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Columbia"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Crawford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dane"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dodge"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Door"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Douglas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dunn"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Eau Claire"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Florence"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Adams"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fond du Lac"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Forest"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grant"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Green"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Green Lake"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Iowa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Iron"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jackson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jefferson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Juneau"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ashland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kenosha"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kewaunee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "La Crosse"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lafayette"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lake Michigan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lake Superior"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Langlade"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lincoln"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Manitowoc"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marathon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Barron"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marinette"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Marquette"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Menominee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Milwaukee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Monroe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Oconto"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Oneida"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.47_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Outagamie"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.48_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ozaukee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.49_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pepin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bayfield"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.50_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pierce"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.51_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Polk"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.52_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Portage"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.53_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Price"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.54_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Racine"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.55_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Richland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.56_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rock"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.57_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rusk"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.58_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saint Croix"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.59_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sauk"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Brown"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.60_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sawyer"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.61_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Shawano"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.62_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sheboygan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.63_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Taylor"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.64_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Trempealeau"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.65_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Vernon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.66_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Vilas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.67_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Walworth"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.68_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washburn"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.69_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Buffalo"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.70_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Waukesha"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.71_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Waupaca"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.72_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Waushara"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.73_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Winnebago"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.74_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wood"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Burnett"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Calumet"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chippewa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.50_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wisconsin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.51.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Johnson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.51.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Laramie"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.51.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lincoln"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.51.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Natrona"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.51.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Niobrara"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.51.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Park"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.51.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Platte"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.51.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sheridan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.51.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sublette"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.51.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sweetwater"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.51.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Albany"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.51.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Teton"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.51.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Uinta"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.51.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washakie"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.51.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Weston"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.51.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Big Horn"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.51.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Campbell"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.51.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Carbon"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.51.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Converse"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.51.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Crook"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.51.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fremont"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.51.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Goshen"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.51.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hot Springs"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.51_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Wyoming"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "California"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.10_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Cheyenne"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.11_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Clear Creek"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.12_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Conejos"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.13_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Costilla"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.14_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Crowley"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.15_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Custer"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.16_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Delta"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.17_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Denver"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.18_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Dolores"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.19_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Douglas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Adams"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.20_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Eagle"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.21_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "El Paso"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.22_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Elbert"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.23_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fremont"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.24_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Garfield"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.25_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gilpin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.26_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Grand"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.27_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Gunnison"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.28_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hinsdale"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.29_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Huerfano"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Alamosa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.30_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jackson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.31_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Jefferson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.32_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kiowa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.33_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kit Carson"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.34_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "La Plata"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.35_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lake"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.36_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Larimer"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.37_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Las Animas"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.38_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Lincoln"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.39_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Logan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Arapahoe"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.40_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mesa"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.41_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Mineral"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.42_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Moffat"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.43_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Montezuma"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.44_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Montrose"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.45_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Morgan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.46_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Otero"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.47_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Ouray"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.48_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Park"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.49_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Phillips"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Archuleta"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.50_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pitkin"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.51_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Prowers"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.52_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Pueblo"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.53_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rio Blanco"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.54_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Rio Grande"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.55_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Routt"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.56_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Saguache"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.57_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "San Juan"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.58_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "San Miguel"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.59_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sedgwick"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Baca"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.60_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Summit"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.61_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Teller"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.62_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Washington"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.63_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Weld"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.64_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Yuma"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Bent"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Boulder"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Broomfield"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Chaffee"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Colorado"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.7.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Fairfield"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.7.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Hartford"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.7.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Litchfield"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.7.4_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Middlesex"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.7.5_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "New Haven"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.7.6_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "New London"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.7.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Tolland"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.7.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Windham"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.7_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Connecticut"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.8.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Kent"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.8.2_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "New Castle"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.8.3_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Sussex"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.8_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "Delaware"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.9.1_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "District of Columbia"
+        }
+      },
+      {
+        "admin" : {
+          "type" : "uri",
+          "value" : "http://stko-kwg.geog.ucsb.edu/lod/resource/Earth.North_America.United_States.USA.9_1"
+        },
+        "admin_label" : {
+          "type" : "literal",
+          "value" : "District of Columbia"
+        }
+      }
+    ]
+  }
+}

--- a/dr-app/public/js/query.js
+++ b/dr-app/public/js/query.js
@@ -269,6 +269,41 @@ async function getAdministrativeRegion() {
     return { 'regions': formattedResults };
 }
 
+async function getNonHierarchicalAdministrativeRegion() {
+    let formattedResults = [];
+
+    let adminQuery = `
+    select distinct ?admin ?admin_label
+    {
+        {
+            ?admin rdf:type kwg-ont:AdministrativeRegion_2;
+                   rdfs:label ?admin_label;
+                   kwg-ont:locatedIn kwgr:Earth.North_America.United_States.USA.
+        }
+        UNION
+        {
+            ?admin rdf:type kwg-ont:AdministrativeRegion_3;
+                   rdfs:label ?admin_label;
+                   kwg-ont:locatedIn ?admin_upper_level.
+            ?admin_upper_level kwg-ont:locatedIn kwgr:Earth.North_America.United_States.USA.
+        }
+    } ORDER BY ASC(?admin)`;
+
+    // use cached data for now
+    // let queryResults = await query(adminQuery);
+    us_admin_regions_nonhierarchical_json = await fetch("/cache/us_admin_regions_nonhierarchical.json");
+    us_admin_regions_nonhierarchical_cached = await us_admin_regions_nonhierarchical_json.json();
+    let queryResults = us_admin_regions_nonhierarchical_cached.results.bindings;
+
+    for (let row of queryResults) {
+        let admin = row.admin.value;
+        let admin_label = row.admin_label.value;
+        formattedResults[admin_label] = admin;
+    }
+
+    return { 'regions': formattedResults };
+}
+
 async function getZipCodeArea() {
     let formattedResults = [];
 

--- a/dr-app/public/js/results_search.js
+++ b/dr-app/public/js/results_search.js
@@ -650,6 +650,36 @@ kwgApp.controller("results-controller", function($scope) {});
 
 kwgApp.controller("spatialmap-controller", function($scope) {});
 
+// Directive that's responsible for autofilling the admin region field
+kwgApp.directive('regionDirective', function() {
+    return {
+        restrict: 'C',
+        require: 'ngModel',
+        link: function(scope, element, attrs, ngModelCtrl) {
+            getNonHierarchicalAdministrativeRegion().then(function(data) {
+                if (element[0] == angular.element('#placeFacetsRegion')[0]) {
+                    element.autocomplete({
+                        source: function(request, response)
+                        {
+                            var matches = $.map(Object.keys(data['regions']), function(item){
+                                if (item.toUpperCase().indexOf(request.term.toUpperCase()) === 0)
+                                {
+                                    return item;
+                                }
+                            });
+                            response(matches);
+                        },
+                        select: function(event, ui) {
+                            ngModelCtrl.$setViewValue(ui.item);
+                            scope.$apply();
+                        }
+                    });
+                }
+            });
+        }
+    }
+});
+
 // Directive that's responsible for autofilling the zipcode field
 kwgApp.directive('zipDirective', function() {
     return {
@@ -710,6 +740,7 @@ kwgApp.directive('uscdDirective', function() {
     }
 });
 
+// Directive that's responsible for autofilling the nwzone field
 kwgApp.directive('nwzDirective', function() {
     return {
         restrict: 'C',

--- a/dr-app/public/pages/dr_resultsSearch.html
+++ b/dr-app/public/pages/dr_resultsSearch.html
@@ -40,7 +40,7 @@
                 <p class="filter-title">PLACE</p>
                 <div class="filter">
                     <div>Administrative Region</div>
-                    <input autocomplete="true" type="text" class="form-control" id="placeFacetsRegion" ng-model="placeFacetsRegion" ng-enter="placeFacetChanged()" placeholder="Find an Administrative Region...">
+                    <input autocomplete="true" type="text" class="form-control region-directive" id="placeFacetsRegion" ng-model="placeFacetsRegion" ng-enter="placeFacetChanged()" placeholder="Find an Administrative Region...">
                     <div>Zip Code</div>
                     <input autocomplete="true" type="text" class="form-control zip-directive" id="placeFacetsZip" ng-model="placeFacetsZip" ng-enter="placeFacetChanged()" placeholder="Find a Zip Code...">
                     <div>US Climate Division</div>


### PR DESCRIPTION
(1) There is an AND logic between placesConnectedToS2 selection and placesHaveLocatedInRelations; (2) There is an OR logic between Admin region selection  and NWZone selection (which both are associated with hazards through locatedIn relations; (3) There is an OR logic between climate division selection and zipcode selection (which both are associated with hazards through s2 cells.
