### PR TITLE
Transitively query places

### DIFF
--- a/src/app/services/query.service.ts
+++ b/src/app/services/query.service.ts
@@ -573,7 +573,7 @@ export class QueryService {
             ?entity kwg-ont:spatialRelation ?s2Cell .
             ?s2Cell rdf:type kwg-ont:KWGCellLevel13 .
             values ?placesConnectedToS2 { ${placeEntitiesConnected} }
-            ?s2Cell kwg-ont:spatialRelation ?placesConnectedToS2.
+            ?s2Cell kwg-ont:spatialRelation+ ?placesConnectedToS2.
         `;
     }
 


### PR DESCRIPTION
Small change that fixes issue #318. By transitively querying the location, we can ask for places in states and countries.