### PR TITLE
Add a 404 page

### DIFF
--- a/src/app/not-found/not-found.component.html
+++ b/src/app/not-found/not-found.component.html
@@ -1,0 +1,4 @@
+<div>
+    <h3>Page Not Found</h3>
+    <p>Redirecting to the homepage</p>
+</div>

--- a/src/app/not-found/not-found.component.ts
+++ b/src/app/not-found/not-found.component.ts
@@ -1,0 +1,20 @@
+import { Component, OnInit } from '@angular/core';
+import {Router} from "@angular/router"
+
+@Component({
+  selector: 'app-not-found',
+  templateUrl: './not-found.component.html',
+  styleUrls: ['./not-found.component.scss']
+})
+export class NotFoundComponent implements OnInit {
+
+  constructor(private router: Router) { }
+
+  ngOnInit(): void {
+    setTimeout(() => {
+      this.router.navigate(['/']);
+      // Sleep for 2 seconds and then redirect
+    }, 2000);
+  }
+
+}


### PR DESCRIPTION
This PR adds a small 404 page that is shown for two seconds before redirecting to the main faceted search landing page, /.

Resolves issue #289 

![image](https://user-images.githubusercontent.com/9289652/205459996-92ff9af9-4b9d-46af-a0e2-a7791b106773.png)
