### PR TITLE
Filter Facet Names

### DIFF
--- a/src/app/facets/facets.component.ts
+++ b/src/app/facets/facets.component.ts
@@ -4,7 +4,7 @@ import { ActivatedRoute, Params, Router } from '@angular/router';
 import { QueryService } from '../services/query.service'
 import { ITreeOptions, TreeNode, TREE_ACTIONS, IActionMapping, TreeModel } from '@circlon/angular-tree-component'
 import { Observable, OperatorFunction } from 'rxjs';
-import { debounceTime, distinctUntilChanged, map } from 'rxjs/operators';
+import { debounceTime, distinctUntilChanged, elementAt, map } from 'rxjs/operators';
 
 /**
  * Component for the facet panel. This component is responsible for handling the display
@@ -319,7 +319,6 @@ export class FacetsComponent implements OnInit {
    * facetChanged method because we want to process observation collections here
    */
   hazardFacetChanged(event) {
-
     // Check to see if any nodes were selected.
     let nodeUris = this.getSelectedNodesURIs(this.hazardTree.treeModel);
     // Check to see if it's equal to the previous selection
@@ -342,7 +341,7 @@ export class FacetsComponent implements OnInit {
       if (node.data.name == 'Earthquake') {
         foundEQ = true
       }
-      if (node.data.name == 'NOAA Hurricane Event') {
+      if (node.data.name == 'Hurricane Event') {
         foundNOAA = true;
       }
     });
@@ -761,7 +760,7 @@ export class FacetsComponent implements OnInit {
           let parsedResponse = this.queryService.getResults(response);
           parsedResponse.forEach(element => {
             states.push({
-              name: element['hazard_label']['value'],
+              name: this.concatHazardType(node.data.name, element['hazard_label']['value']),
               hasChildren: element['count']['value'] > 0,
               uri: element['hazard']['value']
             });
@@ -770,6 +769,34 @@ export class FacetsComponent implements OnInit {
         }
       });
     })
+  }
+
+  /**
+   * Takes a hazard type and removes part of its name. For example, 'NOAA Hurricane Event' becomes 'Hurricane Event'
+   * @param hazardName The name of the hazard type
+   */
+  concatHazardType(parentName: string, hazardName: string) {
+    if (parentName === 'MTBS Fire') {
+      if (hazardName !== 'MTBS Fire') {
+        // Return the string after the prefix
+        return hazardName.split('MTBS ').pop()
+      }
+    }
+    // All of the NOAA types need to be modified except for NOAA Hazard because it's top level
+    if (parentName ==='NOAA Hazard') {
+      if (hazardName !== 'NOAA Hazard') {
+        return hazardName.split('NOAA ').pop()
+      }
+    }
+
+ 
+     // Handle NIFC Fire
+     if (parentName ==='NIFC Fire') {
+      if (hazardName !== 'NIFC Fire') {
+        return hazardName.split('NIFC ').pop()
+      }
+    }
+    return hazardName;
   }
 
   /**


### PR DESCRIPTION
This PR resolves #286. When a hazard type facet is opened....

If it's a NOAA parent, then NOAA is removed from the children.
If it's an MTBS parent, then MTBS is removed from the children
Same for NIFC

![Screenshot from 2022-12-03 17-20-45](https://user-images.githubusercontent.com/9289652/205469720-bdd1ff59-c129-4113-a27f-2637607494a4.png)


Here we can see that MTBS has been removed from the MTBS parent - but not for Complex Fire, the facet above.
![Screenshot from 2022-12-03 17-29-34](https://user-images.githubusercontent.com/9289652/205469725-a3ae9407-3eb9-4217-9966-ac70f763f053.png)




